### PR TITLE
Add chunk_size parameter to avoid OOM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ Version 0.2.1
 
 To be released.
 
+- Added ``chunk_size`` parameter on ``write_table_to_workbook()`` and ``write_table_to_worksheet``.
+
 
 Version 0.2.0
 ~~~~~~~~~~~~~

--- a/dodotable_xlsx.py
+++ b/dodotable_xlsx.py
@@ -13,7 +13,8 @@ __all__ = 'write_table_to_workbook', 'write_table_to_worksheet'
 
 def write_table_to_workbook(table, workbook,
                             header_format=None,
-                            date_format=None):
+                            date_format=None,
+                            chunk_size=None):
     if not isinstance(table, Table):
         raise TypeError(
             'table must be an instance of {0.__module__}.{0.__name__} or its '
@@ -33,12 +34,13 @@ def write_table_to_workbook(table, workbook,
         date_format = workbook.add_format({'num_format': 'yyyy-mm-dd'})
     write_table_to_worksheet(table, worksheet,
                              header_format=header_format,
-                             date_format=date_format)
+                             date_format=date_format, chunk_size=chunk_size)
 
 
 def write_table_to_worksheet(table, worksheet,
                              header_format,
-                             date_format):
+                             date_format,
+                             chunk_size):
     logger = logging.getLogger(__name__ + '.write_table_to_worksheet')
     if not isinstance(table, Table):
         raise TypeError(
@@ -57,31 +59,44 @@ def write_table_to_worksheet(table, worksheet,
         worksheet.write(0, col, column.label, header_format)
         logger.debug('Column #%d: %s', col, column.label)
     logger.debug('%s', table.query)
-    table.select(offset=0, limit=table.count + 100)  # rows may become more
-    for i, row in enumerate(table.rows):
-        rn = i + 1
-        logger.debug('Row number: %d', rn)
-        for col, cell in enumerate(row):
-            val = cell.data
-            for mode in 'without_render', 'with_render':
-                # If a cell.data is a plain Python value (e.g. int, str)
-                # these can be adapted by XlsxWriter's renderer.
-                # However, if it's a complext value these need to be rendered
-                # by dodotable prior to be passed to XlsxWriter.
-                try:
-                    if isinstance(cell, LinkedCell):
-                        worksheet.write_url(rn, col, cell.url, string=str(val))
-                    elif (isinstance(val, datetime.date) and
-                          not isinstance(val, datetime.datetime)):
-                        worksheet.write_datetime(rn, col, val, date_format)
+
+    count = table.count
+    offset = 0
+    if chunk_size is None:
+        # rows may become more
+        chunk_size = count + 100
+
+    rn = 0
+    while offset <= count:
+        table.select(offset=offset, limit=chunk_size)
+        logger.debug('Fetch from %d to %d', offset, chunk_size)
+        offset += chunk_size
+
+        for row in table.rows:
+            rn += 1
+            logger.debug('Row number: %d', rn)
+            for col, cell in enumerate(row):
+                val = cell.data
+                for mode in 'without_render', 'with_render':
+                    # If a cell.data is a plain Python value (e.g. int, str)
+                    # these can be adapted by XlsxWriter's renderer.
+                    # However, if it's a complext value these need to be
+                    # rendered by dodotable prior to be passed to XlsxWriter.
+                    try:
+                        if isinstance(cell, LinkedCell):
+                            worksheet.write_url(rn, col, cell.url,
+                                                string=str(val))
+                        elif (isinstance(val, datetime.date) and
+                              not isinstance(val, datetime.datetime)):
+                            worksheet.write_datetime(rn, col, val, date_format)
+                        else:
+                            worksheet.write(rn, col, val)
+                    except TypeError:
+                        if mode == 'without_render':
+                            val = cell.repr(val)
+                            if isinstance(val, Markup):
+                                val = val.striptags()
+                            continue
+                        raise
                     else:
-                        worksheet.write(rn, col, val)
-                except TypeError:
-                    if mode == 'without_render':
-                        val = cell.repr(val)
-                        if isinstance(val, Markup):
-                            val = val.striptags()
-                        continue
-                    raise
-                else:
-                    break
+                        break


### PR DESCRIPTION
`table` 객체가 반환하는 결과셋의 사이즈가 클 때 발생하는 OOM을 방지하기 위해서 `chunk_size` 파라미터를 추가했습니다.