### PR TITLE
Fix unicode encode error on python2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,16 @@ Excel (.xlsx) exporter for dodotable_.
 Changelog
 ---------
 
+Version 0.4.1
+~~~~~~~~~~~~~
+
+Released on May 31, 2021.
+
+- Fixed a bug that ``dodotable_xlsx.write_table_to_workbook()`` function had
+  raised ``UnicodeEncodeError`` in python2 when the given ``table``'s label is
+  unicode string.
+
+
 Version 0.4.0
 ~~~~~~~~~~~~~
 

--- a/dodotable_xlsx.py
+++ b/dodotable_xlsx.py
@@ -7,7 +7,7 @@ from xlsxwriter import Workbook
 from xlsxwriter.format import Format
 from xlsxwriter.worksheet import Worksheet
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 __all__ = 'write_table_to_workbook', 'write_table_to_worksheet'
 
 
@@ -42,7 +42,7 @@ def write_table_to_workbook(
     offset = 0
     sheet_number = 1
     while offset < count:
-        worksheet = workbook.add_worksheet('{}_{}'.format(table.label, sheet_number))
+        worksheet = workbook.add_worksheet(u'{}_{}'.format(table.label, sheet_number))
         write_table_to_worksheet(
             table,
             worksheet,


### PR DESCRIPTION
- Fixed a bug that ``dodotable_xlsx.write_table_to_workbook()`` function had
  raised ``UnicodeEncodeError`` in python2 when the given ``table``'s label is
  unicode string.